### PR TITLE
Prepare for maven release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,27 @@ import sbt._
 
 organization := "com.intenthq"
 
+organizationName := "Intent HQ"
+
+organizationHomepage := Some(url("http://www.intenthq.com"))
+
 name := "gander"
 
 description := "Extracts text, metadata from web pages."
+
+homepage := Some(url("https://github.com/intenthq/gander"))
+
+developers := List(
+  Developer(id = "albertpastrana", name = "Albert Pastrana", email = "", url = new URL("https://github.com/albertpastrana")),
+  Developer(id = "ArturSoler", name = "Artur Soler", email = "", url = new URL("https://github.com/ArturSoler"))
+)
+
+scmInfo := Some(
+  ScmInfo(
+    browseUrl = new URL("https://github.com/intenthq/gander"),
+    connection = "scm:git:git@github.com:intenthq/gander.git"
+  )
+)
 
 licenses += "Apache2" -> url("http://www.apache.org/licenses/")
 
@@ -39,5 +57,7 @@ libraryDependencies ++= Seq(
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 
 publishTo := Some("Sonatype Snapshots Nexus" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
+
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
 
 lazy val root = project.in(file(".")).configs(IntegrationTest)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9-RC3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")


### PR DESCRIPTION
- Add required project settings
- Add sbt-pgp plugin
- Configure sbt-release to sign the artifact before publishing it. 
- Upgrade SBT to 0.13.9-RC3 (as there is a bug on the pom.xml generation in sbt 0.13.8)
