### PR TITLE
Fix parsing of BBC.co.uk content

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9

--- a/src/it/scala/com/intenthq/gander/GanderIT.scala
+++ b/src/it/scala/com/intenthq/gander/GanderIT.scala
@@ -42,7 +42,7 @@ class GanderIT extends Specification {
                    Link("DRY", "http://en.wikipedia.org/wiki/Don%27t_repeat_yourself")))
   }
 
-  "bbc" >> {
+  "bbc.com" >> {
     val url = "http://www.bbc.com/news/business-33697945"
     check(extract(url),
       url = url,
@@ -55,6 +55,20 @@ class GanderIT extends Specification {
       links = List(Link("Financial Times said", "http://www.ft.com/cms/s/0/27e42c8e-351d-11e5-b05b-b01debd57852.html#axzz3hDFfsPCX"),
                    Link("said in a report", "http://www.ft.com/cms/s/0/27e42c8e-351d-11e5-b05b-b01debd57852.html#axzz3hDFfsPCX")))
 
+  }
+
+  "bbc.co.uk" >> {
+    val url = "http://www.bbc.co.uk/sport/0/football/34203622"
+    check(extract(url),
+      url = url,
+      content = "Manchester City striker Sergio Aguero will miss Tuesday's Champions League opener against Juventus at Etihad Stadium because of a knee injury",
+      title = "BBC Sport",
+      metaDescription = "Manchester City striker Sergio Aguero will miss Tuesday's Champions League opener against Juventus with a knee injury.",
+      metaKeywords = "BBC, Sport, BBC Sport, bbc.co.uk, world, uk, international, foreign, british, online, service",
+      lang = Some("en-GB"),
+      date = None,
+      links = List(Link("City's 1-0 win at Crystal Palace", "http://m.bbc.co.uk/sport/football/34160754"),
+                   Link("losing 3-1 on aggregate", "http://www.bbc.co.uk/sport/0/football/31922160")))
   }
 
   "businessinsider" >> {

--- a/src/main/scala/com/intenthq/gander/DocumentCleaner.scala
+++ b/src/main/scala/com/intenthq/gander/DocumentCleaner.scala
@@ -15,7 +15,7 @@ object DocumentCleaner {
    * this regex is used to remove undesirable nodes from our doc
    * indicate that something maybe isn't content but more of a comment, footer or some other undesirable node
    */
-  private val regExRemoveNodes = "^side$|combx|retweet|mediaarticlerelated|menucontainer|navbar|comment(?!ed)|PopularQuestions|contact|foot|footer|Footer|footnote|cnn_strycaptiontxt|links|meta$|scroll(?!able)|shoutbox|sponsor" +
+  private val regExRemoveNodes = "^side$|combx|retweet|mediaarticlerelated|menucontainer|navbar|comment(?!ed)|PopularQuestions|contact|footer|Footer|footnote|cnn_strycaptiontxt|links|meta$|scroll(?!able)|shoutbox|sponsor" +
     "|tags|socialnetworking|socialNetworking|cnnStryHghLght|cnn_stryspcvbx|^inset$|pagetools|post-attributes|welcome_form|contentTools2|the_answers|remember-tool-tip" +
     "|communitypromo|promo_holder|runaroundLeft|subscribe|vcard|articleheadings|date|^print$|popup|author-dropdown|tools|socialtools|byline|konafilter|KonaFilter|breadcrumbs|^fn$|wp-caption-text"
   private val queryNaughtyIDs = "[id~=(" + regExRemoveNodes + ")]"
@@ -49,7 +49,7 @@ object DocumentCleaner {
     }
 
   private def removeScriptsAndStyles(implicit doc: Document): Unit =
-    (byTag("script") ++ byTag("style")).foreach(remove)
+    (byTag("script") ++ byTag("style") ++ byTag("noscript")).foreach(remove)
 
   private def cleanBadTags(implicit doc: Document): Unit =
     (select(queryNaughtyIDs) ++ select(queryNaughtyClasses) ++ select(queryNaughtyNames)).foreach(remove)


### PR DESCRIPTION
Do not filter tags with an id containing "foot", as it breaks some legitimate content tags (e.g. "football")
