### PR TITLE
Enable sbt cross-build for Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,9 @@ scmInfo := Some(
 
 licenses += "Apache2" -> url("http://www.apache.org/licenses/")
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.11"
+
+crossScalaVersions := Seq("2.11.11", "2.12.4")
 
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
@@ -49,7 +51,7 @@ libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "1.8.1",
   "org.jsoup" % "jsoup" % "1.9.1",
   "org.slf4j"	% "slf4j-api"	% "1.7.21",
-  "org.specs2" %% "specs2-core" % "3.7.3" % "it,test"
+  "org.specs2" %% "specs2-core" % "4.0.2" % "it,test"
 )
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.9")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.2")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")


### PR DESCRIPTION
- Update sbt dependencies for 2.12
- Update 2.11 Scala version to 2.11.11
- Update sbt plugins to latest versions

To cross compile, you need to run `sbt +package` or `sbt +publish`